### PR TITLE
feat: 6-phase funnel tracking + Microsoft Clarity

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -925,14 +925,19 @@ function App() {
 	};
 
 	const handleFixedServices = () => {
+		const normalized = seletedService
+			? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "")
+			: "";
 
 		const service = {
-			specialPromotion25min: seletedService ? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "").search("specialpromotion25min") : "",
-			genderdetermination: seletedService ? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "").search("genderdetermination") : "",
-			earlypregnancy: seletedService ? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "").search("earlypregnancy") : "",
-			meetyourbaby25: seletedService ? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "").search("meetyourbaby25") : "",
-			meetyourbaby15: seletedService ? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "").search("meetyourbaby15") : "",
-			peaceofmind: seletedService ? seletedService?.label?.toLowerCase().replace(/[-.()+\s]/g, "").search("peaceofmind") : "",
+			specialPromotion25min: normalized ? normalized.search("specialpromotion25min") : "",
+			genderdetermination: normalized
+				? Math.max(normalized.search("genderdetermination"), normalized.search("genderreveal"))
+				: "",
+			earlypregnancy: normalized ? normalized.search("earlypregnancy") : "",
+			meetyourbaby25: normalized ? normalized.search("meetyourbaby25") : "",
+			meetyourbaby15: normalized ? normalized.search("meetyourbaby15") : "",
+			peaceofmind: normalized ? normalized.search("peaceofmind") : "",
 		}
 		setFixedServices((fixedServices) => ({
 			...fixedServices,

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import * as crypto from "crypto-js";
 
 function App() {
 	const params = new URLSearchParams(window.location.search);
+	const ENABLE_WEEK_SERVICE_FILTER = process.env.REACT_APP_ENABLE_WEEK_SERVICE_FILTER === "true";
 	const languageList = { en: "English", es: "Spanish" };
 	const [firstLoad, setFirstLoad] = useState(true);
 	const [localTime, setLocalTime] = useState({ date: new Date() });//revisar esta linea Trabajar con la fecha y hora del sitio
@@ -1333,6 +1334,7 @@ function App() {
 					setState={setState}
 					params={params}
 					weeks={weeks}
+					enableWeekServiceFilter={ENABLE_WEEK_SERVICE_FILTER}
 					watch={watch}
 					setValue={setValue}
 					services={services}

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import "bootstrap/dist/css/bootstrap.min.css";
 import moment from "moment";
 import "./App.css";
+import { createLead, updateLead } from "./services/leadTracking";
+import { trackFunnel } from "./services/analytics";
+import usePartialLeadCapture from "./hooks/usePartialLeadCapture";
 import "./styles/info.css";
 import StepProgress from "../src/components/stepProgress";
 import RegisterForm from "../src/components/registerForm";
@@ -105,7 +108,11 @@ function App() {
 		leadUpdate: false,
 		partititonKey: "",
 		orderKey: "",
+		lastSentStep: -1,
+		inFlight: false,
 	});
+	// Guards the step-0 create against React StrictMode's double effect invoke.
+	const step0FiredRef = useRef(false);
 
 	const parent_origin = `${process.env.REACT_APP_FOLLOWING_URL}`;
 	const scrollParenTop = () => {
@@ -728,6 +735,55 @@ function App() {
 		handleSubmit,
 	} = useForm();
 
+	// Step 0 (entered funnel): create the lead once the auth token + siteId are
+	// ready. The token arrives asynchronously, so this re-runs when it lands.
+	// A ref guards against StrictMode's double invoke / duplicate creates.
+	useEffect(() => {
+		if (!state.authorization || !state.siteId) return;
+		if (step0FiredRef.current || leadState.partititonKey) return;
+		step0FiredRef.current = true;
+		setLeadState((s) => ({ ...s, inFlight: true }));
+		createLead({
+			authorization: state.authorization,
+			siteId: state.siteId,
+			service: seletedService?.label ?? "",
+			step: 0,
+			language: state.language,
+		})
+			.then((r) => {
+				setLeadState((s) => ({
+					...s,
+					partititonKey: r.partititonKey,
+					orderKey: r.orderKey,
+					lastSentStep: 0,
+					inFlight: false,
+				}));
+				trackFunnel(0);
+			})
+			.catch((e) => {
+				step0FiredRef.current = false;
+				setLeadState((s) => ({ ...s, inFlight: false }));
+				console.error("lead step 0", e);
+			});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [state.authorization, state.siteId]);
+
+	// Step 0.5 (contact captured): debounced partial-lead capture as the user
+	// types a valid email/phone in the register form.
+	usePartialLeadCapture({
+		authorization: state.authorization,
+		siteId: state.siteId,
+		language: state.language,
+		firstName: watch("firstName"),
+		lastName: watch("lastName"),
+		email: watch("email"),
+		phone: watch("phone"),
+		service: watch("service")?.label || (seletedService?.label ?? ""),
+		leadState,
+		setLeadState,
+		disabled: leadState.lastSentStep >= 1,
+	});
+
 	useEffect(() => {
 		updateDimensions();
 
@@ -853,47 +909,52 @@ function App() {
 					clientFound: false,
 				}));
 			}
-			const leadPayload = {
-				siteId: state.siteId,
+			// Step 1 (info done): update the existing lead (created at step 0) with
+			// the full contact info, or create it if the step-0/0.5 create never
+			// landed. Phone normalized to digits inside the helper.
+			const resolvedClientId = clientId === undefined ? "n/a" : clientId;
+			const contactFields = {
 				name: data.firstName + " " + data.lastName,
 				mobilePhone: data.phone.replace(/[^0-9]/gi, ''),
 				email: data.email,
 				service: sessionTypeName,
-				clientId: clientId === undefined ? "n/a" : clientId,
-				dateTime: moment().format("YYYY-MM-DD[T]HH:mm:ss").toString(),
-				step: 1,
-				language: state.language,
+				clientId: resolvedClientId,
 			};
-			const leadRequest = {
-				method: "POST",
-				headers: {
-					"Content-type": "application/json; charset=UTF-8",
-					authorization: state.authorization,
-					siteid: state.siteId,
-				},
-				body: JSON.stringify(leadPayload),
-			};
-			const leadResponse = await fetch(
-				`${process.env.REACT_APP_API_URL}/api/book/clients`,
-				leadRequest
-			);
-			const leadData = await leadResponse.json();
-			if (leadResponse.ok) {
-				setLeadState((leadState) => ({
-					...leadState,
-					clientFound: true,
-					leadRegistered: true,
-					partititonKey: leadData.partititonKey,
-					orderKey: leadData.orderKey,
-				}));
-			} else {
-				setLeadState((leadState) => ({
-					...leadState,
-					clientFound: true,
-					leadRegistered: false,
-				}));
-				console.log("Error registering lead");
-				console.error(leadData);
+			try {
+				if (leadState.partititonKey && leadState.orderKey) {
+					await updateLead({
+						authorization: state.authorization,
+						siteId: state.siteId,
+						partititonKey: leadState.partititonKey,
+						orderKey: leadState.orderKey,
+						fields: { step: 1, ...contactFields },
+					});
+					setLeadState((leadState) => ({
+						...leadState,
+						clientFound: true,
+						leadRegistered: true,
+						lastSentStep: 1,
+					}));
+				} else {
+					const created = await createLead({
+						authorization: state.authorization,
+						siteId: state.siteId,
+						...contactFields,
+						step: 1,
+						language: state.language,
+					});
+					setLeadState((leadState) => ({
+						...leadState,
+						clientFound: true,
+						leadRegistered: true,
+						partititonKey: created.partititonKey,
+						orderKey: created.orderKey,
+						lastSentStep: 1,
+					}));
+				}
+				trackFunnel(1);
+			} catch (leadError) {
+				console.error("Error registering lead (step 1)", leadError);
 			}
 		} catch (error) {
 			setState((state) => ({

--- a/src/components/boookAppointment.js
+++ b/src/components/boookAppointment.js
@@ -5,6 +5,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { removeTags } from "../config/constans";
 import { getIp } from "../services/external";
+import { updateLead } from "../services/leadTracking";
+import { trackFunnel } from "../services/analytics";
 
 function BookAppointment({
 	state,
@@ -224,44 +226,32 @@ function BookAppointment({
 					const dynamoResponse = await fetch(`${process.env.REACT_APP_API_URL}/api/dynamoDB/appointments`, putDynamo);
 					const dynamoData = await dynamoResponse.json();
 					if (dynamoResponse.ok) {
-						if (leadState.leadRegistered) {
-							const leadPayload = {
-								partititonKey: leadState.partititonKey,
-								orderKey: leadState.orderKey,
-							};
-							const leadRequest = {
-								method: "DELETE",
-								headers: {
-									"Content-type": "application/json; charset=UTF-8",
+						// Step 4 (completed): mark the lead booked and KEEP it, so the
+						// funnel report can count conversions. (Previously the lead was
+						// DELETEd here, which made the widget invisible in the funnel.)
+						setState((state) => ({
+							...state,
+							appointmentRequestStatus: "BOOK-APPOINTMENT-OK",
+						}));
+						if (leadState.partititonKey && leadState.orderKey) {
+							try {
+								await updateLead({
 									authorization: state.authorization,
-									siteid: state.siteId,
-								},
-								body: JSON.stringify(leadPayload),
-							};
-							const leadResponse = await fetch(`${process.env.REACT_APP_API_URL}/api/book/clients`, leadRequest);
-							const leadData = await leadResponse.json();
-							if (leadResponse.ok) {
+									siteId: state.siteId,
+									partititonKey: leadState.partititonKey,
+									orderKey: leadState.orderKey,
+									fields: { step: 4 },
+								});
 								setLeadState((leadState) => ({
 									...leadState,
-									leadDeleted: true,
+									lastSentStep: 4,
 								}));
-								setState((state) => ({
-									...state,
-									appointmentRequestStatus: "BOOK-APPOINTMENT-OK",
-								}));
-							} else {
-								setState((state) => ({
-									...state,
-									appointmentRequestStatus: "BOOK-APPOINTMENT-OK",
-								}));
-								setLeadState((leadState) => ({
-									...leadState,
-									leadDeleted: false,
-								}));
-								console.log("Error deleting lead");
-								console.error(leadData);
+							} catch (leadError) {
+								// Best-effort — the booking already succeeded.
+								console.error("Error marking lead completed (step 4)", leadError);
 							}
 						}
+						trackFunnel(4);
 						googleTrackBooking({
 							name: clientState.firstName + " " + clientState.lastName,
 							service: clientState.sessionTypeName,

--- a/src/components/registerForm.js
+++ b/src/components/registerForm.js
@@ -11,6 +11,7 @@ function RegisterForm({
   setState,
   params,
   weeks,
+  enableWeekServiceFilter,
   watch,
   setValue,
   services,
@@ -36,9 +37,12 @@ function RegisterForm({
   setModal8kRealisticView,
   setClickButtonForm,
 }) {
+  const shouldFilterByWeek = Boolean(enableWeekServiceFilter);
   const selectedWeeks = watch ? watch("weeks") : null;
   const selectedWeekNum =
-    selectedWeeks?.value != null && selectedWeeks.value !== "I don't know"
+    shouldFilterByWeek &&
+    selectedWeeks?.value != null &&
+    selectedWeeks.value !== "I don't know"
       ? parseInt(selectedWeeks.value, 10)
       : null;
   const filteredServices =
@@ -73,6 +77,7 @@ function RegisterForm({
     filteredServices.some((g) => (g.options || []).length > 0);
 
   useEffect(() => {
+    if (!shouldFilterByWeek) return;
     if (!setValue || selectedWeekNum == null) return;
     const currentService = watch ? watch("service") : null;
     if (!currentService?.value) return;
@@ -80,7 +85,7 @@ function RegisterForm({
       (g) => (g.options || []).some((o) => o.value === currentService.value)
     );
     if (!inFiltered) setValue("service", null);
-  }, [selectedWeekNum, filteredServices, watch, setValue]);
+  }, [selectedWeekNum, filteredServices, shouldFilterByWeek, watch, setValue]);
 
   const selectStyles = {
     option: (styles, { data, isDisabled, isFocused, isSelected }) => {
@@ -449,6 +454,7 @@ RegisterForm.propTypes = {
   setState: PropTypes.func.isRequired,
   params: PropTypes.object.isRequired,
   weeks: PropTypes.array.isRequired,
+  enableWeekServiceFilter: PropTypes.bool,
   watch: PropTypes.func,
   setValue: PropTypes.func,
   services: PropTypes.array.isRequired,

--- a/src/components/registerForm.js
+++ b/src/components/registerForm.js
@@ -47,11 +47,23 @@ function RegisterForm({
           .map((group) => ({
             ...group,
             options: (group.options || []).filter(
-              (opt) =>
-                opt.start_week == null ||
-                opt.end_week == null ||
-                (selectedWeekNum >= opt.start_week &&
-                  selectedWeekNum <= opt.end_week)
+              (opt) => {
+                const startWeek = parseInt(opt.start_week, 10);
+                const endWeek = parseInt(opt.end_week, 10);
+                const hasStart = !Number.isNaN(startWeek);
+                const hasEnd = !Number.isNaN(endWeek);
+
+                if (hasStart && hasEnd) {
+                  return selectedWeekNum >= startWeek && selectedWeekNum <= endWeek;
+                }
+                if (hasStart) {
+                  return selectedWeekNum >= startWeek;
+                }
+                if (hasEnd) {
+                  return selectedWeekNum <= endWeek;
+                }
+                return true;
+              }
             ),
           }))
           .filter((group) => group.options.length > 0)

--- a/src/components/selectTimeAppointment-v2.js
+++ b/src/components/selectTimeAppointment-v2.js
@@ -4,6 +4,8 @@ import DatePicker from "react-horizontal-datepicker";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import moment from "moment";
+import { updateLead } from "../services/leadTracking";
+import { trackFunnel } from "../services/analytics";
 
 function formatDate(dateString) {
 	const date = new Date(dateString);
@@ -110,36 +112,20 @@ function SelectTimeAppointmentV2({ setStepTwo, previousStep, state, setState, se
 		setSelectBlock(block.startDateTime);
 
 		try {
-			if (leadState.leadRegistered) {
-				const leadPayload = {
-					partitionKey: leadState.partititonKey,
+			if (leadState.partititonKey && leadState.orderKey) {
+				await updateLead({
+					authorization: state.authorization,
+					siteId: state.siteId,
+					partititonKey: leadState.partititonKey,
 					orderKey: leadState.orderKey,
-					dateTimeSeleted: block.startDateTime,
-					step: 2,
-				};
-				const leadRequest = {
-					method: "PUT",
-					headers: {
-						"Content-type": "application/json; charset=UTF-8",
-						authorization: state.authorization,
-						siteid: state.siteId,
-					},
-					body: JSON.stringify(leadPayload),
-				};
-				const leadResponse = await fetch(`${process.env.REACT_APP_API_URL}/api/book/clients`, leadRequest);
-				const leadData = await leadResponse.json();
-				if (leadResponse.ok) {
-					setLeadState((leadState) => ({
-						...leadState,
-						leadUpdate: true,
-					}));
-				} else {
-					setLeadState((leadState) => ({
-						...leadState,
-						leadUpdate: true,
-					}));
-					console.error(leadData);
-				}
+					fields: { dateTimeSeleted: block.startDateTime, step: 2 },
+				});
+				setLeadState((leadState) => ({
+					...leadState,
+					leadUpdate: true,
+					lastSentStep: 2,
+				}));
+				trackFunnel(2);
 			}
 		} catch (error) {
 			console.error(error);
@@ -179,38 +165,20 @@ function SelectTimeAppointmentV2({ setStepTwo, previousStep, state, setState, se
 		}));
 
 		try {
-			if (leadState.leadRegistered) {
-				const leadPayload = {
-					partitionKey: leadState.partititonKey,
+			if (leadState.partititonKey && leadState.orderKey) {
+				await updateLead({
+					authorization: state.authorization,
+					siteId: state.siteId,
+					partititonKey: leadState.partititonKey,
 					orderKey: leadState.orderKey,
-					dateTimeSeleted: selectedBlock,
-					step: 3,
-				};
-				const leadRequest = {
-					method: "PUT",
-					headers: {
-						"Content-type": "application/json; charset=UTF-8",
-						authorization: state.authorization,
-						siteid: state.siteId,
-					},
-					body: JSON.stringify(leadPayload),
-				};
-
-				const leadResponse = await fetch(`${process.env.REACT_APP_API_URL}/api/book/clients`, leadRequest);
-
-				const leadData = await leadResponse.json();
-				if (leadResponse.ok) {
-					setLeadState((leadState) => ({
-						...leadState,
-						leadUpdate: true,
-					}));
-				} else {
-					setLeadState((leadState) => ({
-						...leadState,
-						leadUpdate: true,
-					}));
-					console.error(leadData);
-				}
+					fields: { dateTimeSeleted: selectedBlock, step: 3 },
+				});
+				setLeadState((leadState) => ({
+					...leadState,
+					leadUpdate: true,
+					lastSentStep: 3,
+				}));
+				trackFunnel(3);
 			}
 		} catch (error) {
 			console.error(error);

--- a/src/hooks/usePartialLeadCapture.js
+++ b/src/hooks/usePartialLeadCapture.js
@@ -1,0 +1,166 @@
+import { useEffect, useRef } from "react";
+import { createLead, updateLead, flushLeadKeepalive } from "../services/leadTracking";
+import { trackFunnel } from "../services/analytics";
+
+const DEBOUNCE_MS = 1500;
+const STEP_PARTIAL = 0.5;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Step 0.5 of the funnel — the user typed a valid email OR a 10+ digit phone in
+ * the register form but hasn't submitted yet. Promotes the step-0 lead to step
+ * 0.5 with the captured contact info (or creates one if the step-0 create lost
+ * a race). Fires once, debounced, with a keepalive unload safety net.
+ *
+ * React 17 + react-hook-form: this hook is mounted in App.js and fed the
+ * `watch(...)` field values, plus leadState/setLeadState (App owns lead state).
+ */
+export default function usePartialLeadCapture({
+  authorization,
+  siteId,
+  language,
+  firstName,
+  lastName,
+  email,
+  phone,
+  service,
+  leadState,
+  setLeadState,
+  disabled,
+}) {
+  // Latest values for the unload handler (bound once) and the debounced fire.
+  const inputRef = useRef({});
+  inputRef.current = {
+    authorization,
+    siteId,
+    language,
+    firstName,
+    lastName,
+    email,
+    phone,
+    service,
+    leadState,
+    disabled,
+  };
+
+  const phoneDigits = String(phone ?? "").replace(/\D/g, "");
+  const hasContact = EMAIL_RE.test(email || "") || phoneDigits.length >= 10;
+  const alreadySent = leadState.lastSentStep >= STEP_PARTIAL;
+  const isValid =
+    !disabled &&
+    !!siteId &&
+    !!authorization &&
+    hasContact &&
+    !alreadySent &&
+    !leadState.inFlight;
+
+  // Debounced promote to step 0.5 — fires once when contact first becomes valid.
+  useEffect(() => {
+    if (!isValid) return;
+    const handle = setTimeout(async () => {
+      const cur = inputRef.current;
+      if (!cur.siteId || !cur.authorization) return;
+      if (cur.leadState.lastSentStep >= STEP_PARTIAL) return;
+      setLeadState((s) => ({ ...s, inFlight: true }));
+      const fullName = `${cur.firstName || ""} ${cur.lastName || ""}`.trim();
+      try {
+        if (cur.leadState.partititonKey && cur.leadState.orderKey) {
+          await updateLead({
+            authorization: cur.authorization,
+            siteId: cur.siteId,
+            partititonKey: cur.leadState.partititonKey,
+            orderKey: cur.leadState.orderKey,
+            fields: {
+              step: STEP_PARTIAL,
+              name: fullName,
+              mobilePhone: cur.phone,
+              email: cur.email,
+              service: cur.service,
+            },
+          });
+          setLeadState((s) => ({ ...s, lastSentStep: STEP_PARTIAL, inFlight: false }));
+        } else {
+          const r = await createLead({
+            authorization: cur.authorization,
+            siteId: cur.siteId,
+            name: fullName,
+            mobilePhone: cur.phone,
+            email: cur.email,
+            service: cur.service,
+            step: STEP_PARTIAL,
+            language: cur.language,
+          });
+          setLeadState((s) => ({
+            ...s,
+            partititonKey: r.partititonKey,
+            orderKey: r.orderKey,
+            leadRegistered: true,
+            lastSentStep: STEP_PARTIAL,
+            inFlight: false,
+          }));
+        }
+        trackFunnel(STEP_PARTIAL);
+      } catch (e) {
+        setLeadState((s) => ({ ...s, inFlight: false }));
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isValid, setLeadState]);
+
+  // Unload safety net — flush via keepalive if the debounce hasn't fired yet.
+  useEffect(() => {
+    function flush() {
+      const cur = inputRef.current;
+      if (!cur || cur.disabled || !cur.siteId || !cur.authorization) return;
+      if (cur.leadState.lastSentStep >= STEP_PARTIAL) return;
+      const d = String(cur.phone ?? "").replace(/\D/g, "");
+      if (!EMAIL_RE.test(cur.email || "") && d.length < 10) return;
+      const fullName = `${cur.firstName || ""} ${cur.lastName || ""}`.trim();
+      if (cur.leadState.partititonKey && cur.leadState.orderKey) {
+        flushLeadKeepalive({
+          authorization: cur.authorization,
+          siteId: cur.siteId,
+          method: "PUT",
+          body: {
+            partitionKey: cur.leadState.partititonKey,
+            orderKey: cur.leadState.orderKey,
+            step: STEP_PARTIAL,
+            name: fullName,
+            mobilePhone: cur.phone,
+            email: cur.email,
+            service: cur.service,
+          },
+        });
+      } else {
+        flushLeadKeepalive({
+          authorization: cur.authorization,
+          siteId: cur.siteId,
+          method: "POST",
+          body: {
+            siteId: cur.siteId,
+            name: fullName,
+            mobilePhone: cur.phone,
+            email: cur.email,
+            service: cur.service,
+            clientId: "n/a",
+            step: STEP_PARTIAL,
+            language: cur.language,
+          },
+        });
+      }
+    }
+
+    function onVisibility() {
+      if (document.visibilityState === "hidden") flush();
+    }
+
+    window.addEventListener("beforeunload", flush);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("beforeunload", flush);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, []);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { initClarity } from './services/analytics';
+
+// Microsoft Clarity — gated by REACT_APP_ANALYTICS_ENABLED + REACT_APP_CLARITY_ID.
+initClarity();
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -1,0 +1,54 @@
+// Microsoft Clarity integration for the booking widget.
+//
+// The widget runs inside an iframe, so Clarity here records the widget's own
+// session (the booking funnel interactions), which is exactly what we want for
+// funnel analysis. Gated behind REACT_APP_ANALYTICS_ENABLED so QA/test builds
+// never load Clarity or pollute the project (mirrors next-app's analytics flag).
+//
+// CRA inlines `process.env.REACT_APP_*` at build time, so these literals must be
+// referenced directly (no destructuring) and set in the production build env.
+
+const ANALYTICS_ENABLED = process.env.REACT_APP_ANALYTICS_ENABLED === "true";
+const CLARITY_ID = process.env.REACT_APP_CLARITY_ID;
+
+/** Inject the standard Microsoft Clarity snippet. No-op if disabled/missing. */
+export function initClarity() {
+  if (!ANALYTICS_ENABLED || !CLARITY_ID) return;
+  if (typeof window === "undefined" || window.clarity) return;
+  (function (c, l, a, r, i, t, y) {
+    c[a] =
+      c[a] ||
+      function () {
+        (c[a].q = c[a].q || []).push(arguments);
+      };
+    t = l.createElement(r);
+    t.async = 1;
+    t.src = "https://www.clarity.ms/tag/" + i;
+    y = l.getElementsByTagName(r)[0];
+    y.parentNode.insertBefore(t, y);
+  })(window, document, "clarity", "script", CLARITY_ID);
+}
+
+/** Tag the current Clarity session with the funnel step it reached. */
+export function clarityFunnelStep(step) {
+  if (typeof window !== "undefined" && window.clarity) {
+    window.clarity("set", "funnel_step", String(step));
+  }
+}
+
+/** Fire a custom Clarity event. */
+export function clarityEvent(name) {
+  if (typeof window !== "undefined" && window.clarity) {
+    window.clarity("event", name);
+  }
+}
+
+/**
+ * Single entry point the components call at each funnel phase. Sets the
+ * funnel_step tag and, on completion, fires a `booking_completed` event so
+ * sessions can be filtered/funnelled in the Clarity dashboard.
+ */
+export function trackFunnel(step) {
+  clarityFunnelStep(step);
+  if (Number(step) >= 4) clarityEvent("booking_completed");
+}

--- a/src/services/leadTracking.js
+++ b/src/services/leadTracking.js
@@ -1,0 +1,112 @@
+// Centralized booking-funnel lead tracking against the LB API
+// (`/api/book/clients`). Mirrors the 6-phase model used by the Next.js app:
+// the lead is CREATED once (step 0) and UPDATED through steps 0.5 → 4 reusing
+// the same partititonKey/orderKey. Previously these fetches were scattered
+// across App.js, selectTimeAppointment-v2.js and boookAppointment.js.
+//
+// Spelling note (backend contract):
+//   - POST create RESPONSE returns `partititonKey` (misspelled) + `orderKey`.
+//   - PUT update BODY expects `partitionKey` (correct spelling).
+// We keep `partititonKey` everywhere internally and translate to `partitionKey`
+// only when building the PUT body, here, in one place.
+import moment from "moment";
+
+const API_URL = process.env.REACT_APP_API_URL;
+
+const headers = (authorization, siteId) => ({
+  "Content-type": "application/json; charset=UTF-8",
+  authorization,
+  siteid: siteId,
+});
+
+const digits = (v) => String(v ?? "").replace(/[^0-9]/gi, "");
+
+/**
+ * POST a new incomplete-booking lead. Handles `name` natively (the POST route
+ * stores it explicitly, unlike the dynamic PUT). Returns { partititonKey, orderKey }.
+ */
+export async function createLead({
+  authorization,
+  siteId,
+  name = "",
+  mobilePhone = "",
+  email = "",
+  service = "",
+  clientId = "n/a",
+  step,
+  language,
+  dateTime,
+}) {
+  const body = {
+    siteId,
+    name,
+    mobilePhone: digits(mobilePhone),
+    email,
+    service,
+    clientId: clientId || "n/a",
+    dateTime: dateTime || moment().format("YYYY-MM-DD[T]HH:mm:ss").toString(),
+    step,
+    language,
+  };
+  const res = await fetch(`${API_URL}/api/book/clients`, {
+    method: "POST",
+    headers: headers(authorization, siteId),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`createLead failed: ${res.status}`);
+  return res.json(); // { partititonKey, orderKey }
+}
+
+/**
+ * PUT an update onto an existing lead. `fields` is any subset of
+ * { step, name, mobilePhone, email, service, dateTimeSeleted, clientId }.
+ * The backend aliases attribute names, so reserved words like `name` are safe.
+ */
+export async function updateLead({ authorization, siteId, partititonKey, orderKey, fields = {} }) {
+  const body = { partitionKey: partititonKey, orderKey, ...fields };
+  if (body.mobilePhone != null) body.mobilePhone = digits(body.mobilePhone);
+  const res = await fetch(`${API_URL}/api/book/clients`, {
+    method: "PUT",
+    headers: headers(authorization, siteId),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`updateLead failed: ${res.status}`);
+  return res.json().catch(() => ({}));
+}
+
+/**
+ * Unload safety net: ship a final lead write while the tab is closing.
+ * Uses `fetch(..., {keepalive:true})` because it CAN carry the auth/siteid
+ * headers the backend requires (navigator.sendBeacon cannot set headers and
+ * would 401). Best-effort, fire-and-forget.
+ */
+export function flushLeadKeepalive({ authorization, siteId, method, body }) {
+  try {
+    const payload = { ...body };
+    if (payload.mobilePhone != null) payload.mobilePhone = digits(payload.mobilePhone);
+    fetch(`${API_URL}/api/book/clients`, {
+      method,
+      headers: headers(authorization, siteId),
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * DEPRECATED — leads are no longer deleted on booking success; we PUT step 4
+ * and keep the row so the funnel report can count conversions. Kept exported
+ * in case a manual cleanup path is ever needed.
+ */
+export async function deleteLead({ authorization, siteId, partititonKey, orderKey }) {
+  const res = await fetch(`${API_URL}/api/book/clients`, {
+    method: "DELETE",
+    headers: headers(authorization, siteId),
+    body: JSON.stringify({ partititonKey, orderKey }),
+  });
+  if (!res.ok) throw new Error(`deleteLead failed: ${res.status}`);
+  return res.json().catch(() => ({}));
+}


### PR DESCRIPTION
## Qué

Lleva al widget el mismo modelo de funnel de 6 fases que usa el Next.js app e integra **Microsoft Clarity**.

### Tracking de funnel (un único lead que evoluciona)
| Fase | Antes | Ahora |
|---|---|---|
| 0 entered | — | POST crea el lead al cargar (auth + siteId listos) |
| 0.5 contact | — | debounce 1.5s al escribir email/tel + red de unload |
| 1 info done | POST crea | PUT enriquece con contacto (fallback POST) |
| 2 / 3 | PUT inline | PUT vía helper |
| 4 completed | **DELETE** | **PUT step 4, conserva el lead** |

El cambio clave: en éxito ya **no se borra** el lead → el reporte/funnel puede contar conversiones del widget.

### Microsoft Clarity
`src/services/analytics.js`: `initClarity()` + tag `funnel_step` por paso + evento `booking_completed`. Gated por `REACT_APP_ANALYTICS_ENABLED` + `REACT_APP_CLARITY_ID` (apagado por defecto).

### Archivos
- Nuevos: `src/services/leadTracking.js`, `src/services/analytics.js`, `src/hooks/usePartialLeadCapture.js`
- Editados: `src/App.js`, `src/components/{boookAppointment,selectTimeAppointment-v2}.js`, `src/index.js`

## Deploy / config
- Setear en el build de staging/prod (Amplify env): `REACT_APP_ANALYTICS_ENABLED=true` y `REACT_APP_CLARITY_ID=<id>`. `.env` está gitignored.
- **Depende** del fix del PUT en `little-bellies-self-checkin-api` (alias de `ExpressionAttributeNames`) para guardar `name`. Mergear ese PR a develop a la vez o antes.

## Nota
La rama parte de `main` (develop estaba detrás), así que el PR también sincroniza develop con lo que ya está en main/prod (incluye `feat/filter_by_weeks`).

## Test plan
- Recorrer el funnel en staging con Network filtrado `book/clients`: POST step 0 → PUT 0.5 → PUT 1 → PUT 2 → PUT 3 → **PUT 4 (sin DELETE)**, mismas keys.
- Confirmar en DynamoDB `incompleteBooking` una fila que progresa 0→4 y persiste.
- Clarity: sesión con tag `funnel_step` y evento `booking_completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)