### PR TITLE
feat(clarity): context tags (service, city, lang, site)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -758,7 +758,7 @@ function App() {
 					lastSentStep: 0,
 					inFlight: false,
 				}));
-				trackFunnel(0);
+				trackFunnel(0, { city: state.city, lang: state.language, site: state.siteId });
 			})
 			.catch((e) => {
 				step0FiredRef.current = false;
@@ -952,7 +952,12 @@ function App() {
 						lastSentStep: 1,
 					}));
 				}
-				trackFunnel(1);
+				trackFunnel(1, {
+					service: sessionTypeName,
+					city: state.city,
+					lang: state.language,
+					site: state.siteId,
+				});
 			} catch (leadError) {
 				console.error("Error registering lead (step 1)", leadError);
 			}

--- a/src/components/boookAppointment.js
+++ b/src/components/boookAppointment.js
@@ -251,7 +251,11 @@ function BookAppointment({
 								console.error("Error marking lead completed (step 4)", leadError);
 							}
 						}
-						trackFunnel(4);
+						trackFunnel(4, {
+							service: clientState.sessionTypeName,
+							city: state.city,
+							site: state.siteId,
+						});
 						googleTrackBooking({
 							name: clientState.firstName + " " + clientState.lastName,
 							service: clientState.sessionTypeName,

--- a/src/hooks/usePartialLeadCapture.js
+++ b/src/hooks/usePartialLeadCapture.js
@@ -99,7 +99,11 @@ export default function usePartialLeadCapture({
             inFlight: false,
           }));
         }
-        trackFunnel(STEP_PARTIAL);
+        trackFunnel(STEP_PARTIAL, {
+          service: cur.service,
+          lang: cur.language,
+          site: cur.siteId,
+        });
       } catch (e) {
         setLeadState((s) => ({ ...s, inFlight: false }));
       }

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -43,12 +43,24 @@ export function clarityEvent(name) {
   }
 }
 
+/** Set an arbitrary custom tag (skips empty/null values). */
+export function claritySet(key, value) {
+  if (typeof window !== "undefined" && window.clarity && value != null && value !== "") {
+    window.clarity("set", String(key), String(value));
+  }
+}
+
 /**
  * Single entry point the components call at each funnel phase. Sets the
- * funnel_step tag and, on completion, fires a `booking_completed` event so
- * sessions can be filtered/funnelled in the Clarity dashboard.
+ * funnel_step tag, plus any context tags provided in `meta` (service, city,
+ * lang, site) so sessions can be segmented in the Clarity dashboard, and
+ * fires a `booking_completed` event on completion.
  */
-export function trackFunnel(step) {
+export function trackFunnel(step, meta = {}) {
   clarityFunnelStep(step);
+  claritySet("service", meta.service);
+  claritySet("city", meta.city);
+  claritySet("lang", meta.lang);
+  claritySet("site", meta.site);
   if (Number(step) >= 4) clarityEvent("booking_completed");
 }


### PR DESCRIPTION
## Qué
Extiende `trackFunnel(step, meta)` para setear **custom tags** de Clarity además del `funnel_step`, y así poder **segmentar sesiones** en el dashboard por:
- `service`, `city`, `lang`, `site` (siteId)

Se setean con el contexto disponible en cada paso (city/lang/site en step 0; service en 0.5/1; service/city/site en step 4). Valores vacíos se omiten.

## Archivos
- `src/services/analytics.js` (nuevo `claritySet`, `trackFunnel(step, meta)`)
- `src/App.js`, `src/hooks/usePartialLeadCapture.js`, `src/components/boookAppointment.js` (pasan el meta)

## Notas
- Solo aplica si Clarity está activo (flag `REACT_APP_ANALYTICS_ENABLED`). Build local OK.
- Los tags aparecen como filtros en Clarity tras el procesamiento (~2 h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)