### PR TITLE
fix(leads): locationId/city in step-0.5 fallback create

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -789,6 +789,8 @@ function App() {
 		email: watch("email"),
 		phone: watch("phone"),
 		service: watch("service")?.label || (seletedService?.label ?? ""),
+		locationId: state.locationId,
+		city: state.city,
 		leadState,
 		setLeadState,
 		disabled: leadState.lastSentStep >= 1,

--- a/src/hooks/usePartialLeadCapture.js
+++ b/src/hooks/usePartialLeadCapture.js
@@ -24,6 +24,8 @@ export default function usePartialLeadCapture({
   email,
   phone,
   service,
+  locationId,
+  city,
   leadState,
   setLeadState,
   disabled,
@@ -39,6 +41,8 @@ export default function usePartialLeadCapture({
     email,
     phone,
     service,
+    locationId,
+    city,
     leadState,
     disabled,
   };
@@ -89,6 +93,8 @@ export default function usePartialLeadCapture({
             service: cur.service,
             step: STEP_PARTIAL,
             language: cur.language,
+            locationId: cur.locationId,
+            city: cur.city,
           });
           setLeadState((s) => ({
             ...s,
@@ -151,6 +157,8 @@ export default function usePartialLeadCapture({
             clientId: "n/a",
             step: STEP_PARTIAL,
             language: cur.language,
+            locationId: cur.locationId,
+            city: cur.city,
           },
         });
       }


### PR DESCRIPTION
Los leads creados por el fallback de step 0.5 (contacto tecleado antes de que aterrice el create de step 0) nacían sin `locationId`/`city`, y el flujo de resume no podía resolver su location exacta. Se pasan ambos al create del debounce y al flush keepalive de unload. Build Node 16 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)